### PR TITLE
Fix: type object 'Collection' has no attribute 'load'

### DIFF
--- a/loadbalancer/loadbalancer.py
+++ b/loadbalancer/loadbalancer.py
@@ -509,7 +509,7 @@ def InitConf(self):
 
 
 
-anki.collection._Collection.load = wrap(anki.collection._Collection.load, InitConf, pos="after")
+anki.collection._Collection._loadScheduler = wrap(anki.collection._Collection._loadScheduler, InitConf, pos="before")
 
 
 


### PR DESCRIPTION
Hello,

This commit intends to fix the error due to the removal of anki.collection._Collection.load
(commit on May 15th 2020: a2b7a3084131f747fb476cc8a24f96a00c654859)
See: https://github.com/ankitects/anki/commit/a2b7a3084131f747fb476cc8a24f96a00c654859#diff-286ad1cf4f79bc4880ecbcc7c6a09062

Since the method disappeared I wrapped the following function.
Regards.