### PR TITLE
Fixes error encountered when opening preferences

### DIFF
--- a/loadbalancer/loadbalancer.py
+++ b/loadbalancer/loadbalancer.py
@@ -243,14 +243,14 @@ def NEWsetupUi(self, Preferences):
 
 def NEW__init__(self, mw):
     qc = self.mw.col.conf
-    self.form.lbperb.setValue(qc["LBPercentBefore"]*100)
-    self.form.lbpera.setValue(qc["LBPercentAfter"]*100)
-    self.form.lbmaxb.setValue(qc["LBMaxBefore"])
-    self.form.lbmaxa.setValue(qc["LBMaxAfter"])
-    self.form.lbminb.setValue(qc["LBMinBefore"])
-    self.form.lbmina.setValue(qc["LBMinAfter"])
+    self.form.lbperb.setValue(int(qc["LBPercentBefore"]*100))
+    self.form.lbpera.setValue(int(qc["LBPercentAfter"]*100))
+    self.form.lbmaxb.setValue(int(qc["LBMaxBefore"]))
+    self.form.lbmaxa.setValue(int(qc["LBMaxAfter"]))
+    self.form.lbminb.setValue(int(qc["LBMinBefore"]))
+    self.form.lbmina.setValue(int(qc["LBMinAfter"]))
 
-    self.form.lbwl.setValue(qc["LBWorkload"]*100)
+    self.form.lbwl.setValue(int(qc["LBWorkload"]*100))
     self.form.lbds.setChecked(qc["LBDeckScheduling"])
 
 def NEWaccept(self):


### PR DESCRIPTION
Received the following error when opening preferences on arch linux, using
python 3.10 today:

```
An error occurred. Please start Anki while holding down the shift key, which
will temporarily disable the add-ons you have installed.
If the issue only occurs when add-ons are enabled, please use the
Tools > Add-ons menu item to disable some add-ons and restart Anki, repeating
until you discover the add-on that is causing the problem.
When you've discovered the add-on that is causing the problem, please report
the issue on the add-on support site.

Debug info:
Anki 2.1.49 (nogit) Python 3.10.1 Qt 5.15.2 PyQt 5.15.6
Platform: Linux
Flags: frz=False ao=True sv=2
Add-ons, last update check: 2022-01-24 08:19:46
Add-ons possibly involved: ⁨load balancer⁩

Caught exception:
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/aqt/main.py", line 1139, in onPrefs
    aqt.dialogs.open("Preferences", self)
  File "/usr/lib/python3.10/site-packages/aqt/__init__.py", line 116, in open
    instance = creator(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/usr/lib/python3.10/site-packages/anki/hooks.py", line 89, in decorator_wrapper
    return repl(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/anki/hooks.py", line 81, in repl
    return new(*args, **kwargs)
  File "/home/sk/.local/share/Anki2/addons21/1417170896/loadbalancer.py", line 246, in NEW__init__
    self.form.lbperb.setValue(qc["LBPercentBefore"]*100)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
```

The reason was Qt not liking that some setValue calls were made with floats instead of ints, this PR fixes this issue.